### PR TITLE
Use theme version for assets

### DIFF
--- a/includes/scripts-and-styles.php
+++ b/includes/scripts-and-styles.php
@@ -26,11 +26,9 @@ add_action( 'wp_enqueue_scripts', 'benenson_child_dequeue_styles', 20 );
  */
 if ( ! function_exists( 'benenson_child_enqueue_scripts' ) ) {
 	function benenson_child_enqueue_scripts() {
-		wp_enqueue_style( 'benenson-global-style', get_stylesheet_directory_uri() . '/assets/styles/app.css', [], filemtime( get_stylesheet_directory() . '/assets/styles/app.css' ), 'screen' );
-		wp_enqueue_style( 'benenson-print-style', get_stylesheet_directory_uri() . '/assets/styles/print.css', [], filemtime( get_stylesheet_directory() . '/assets/styles/print.css' ), 'print' );
+		wp_enqueue_style( 'benenson-global-style', get_stylesheet_directory_uri() . '/assets/styles/app.css', [], '1.0.0', 'screen' );
+		wp_enqueue_style( 'benenson-print-style', get_stylesheet_directory_uri() . '/assets/styles/print.css', [], '1.0.0', 'print' );
 	}
 }
 
 add_action( 'wp_enqueue_scripts', 'benenson_child_enqueue_scripts', 20 );
-
-


### PR DESCRIPTION
It's recommended to use the theme version number for asset versions, rather than file modified times.